### PR TITLE
Improve s:run_scene

### DIFF
--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -55,14 +55,14 @@ func! s:run_scene(scene_name) abort
     " if there is vim-dispatch installed, use it
     " vim-dispatch can't Start application in windows neovim :(
     " https://github.com/tpope/vim-dispatch/issues/297
-    if has('win32') && has('nvim')
+    if exists(':AsyncRun')
+        call asyncrun#run('', {}, godot_command)
+    elseif has('win32') && has('nvim')
         call system('start ' . godot_command)
     elseif executable('cmd.exe') && !exists('$TMUX')
         call system('cmd.exe /c start ' . godot_command)
     elseif exists(':Spawn')
         execute 'Spawn ' . godot_command
-    elseif exists(':AsyncRun')
-        call asyncrun#run('', {}, godot_command)
     elseif has("mac") " XXX: need test
         call system('open ' . godot_command)
     else

--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -60,9 +60,9 @@ func! s:run_scene(scene_name) abort
     elseif executable('cmd.exe') && !exists('$TMUX')
         call system('cmd.exe /c start ' . godot_command)
     elseif exists(':Spawn')
-        Spawn godot_command
+        execute 'Spawn ' . godot_command
     elseif exists(':AsyncRun')
-         call asyncrun#run('', {}, godot_command)
+        call asyncrun#run('', {}, godot_command)
     elseif has("mac") " XXX: need test
         call system('open ' . godot_command)
     else

--- a/ftplugin/gdscript.vim
+++ b/ftplugin/gdscript.vim
@@ -41,15 +41,6 @@ func! GDScriptFoldLevel() abort
 
 endfunc
 
-if !exists("g:godot_executable")
-    if executable('godot')
-        let g:godot_executable = 'godot'
-    elseif executable('godot.exe')
-        let g:godot_executable = 'godot.exe'
-    endif
-endif
-
-
 command! -buffer GodotRunCurrent call godot#run_current()
 command! -buffer GodotRunLast call godot#run_last()
 command! -buffer -nargs=? -complete=customlist,godot#scene_complete GodotRun call godot#run(<q-args>)

--- a/ftplugin/gsl.vim
+++ b/ftplugin/gsl.vim
@@ -13,14 +13,6 @@ let b:undo_ftplugin = '|setlocal suffixesadd<'
 setlocal suffixesadd=.shader
 setlocal noexpandtab
 
-if !exists("g:godot_executable")
-    if executable('godot')
-        let g:godot_executable = 'godot'
-    elseif executable('godot.exe')
-        let g:godot_executable = 'godot.exe'
-    endif
-endif
-
 command! -buffer -nargs=? -complete=customlist,godot#scene_complete GodotRun call godot#run(<q-args>)
 command! -buffer GodotRunFZF call godot#fzf_run_scene()
 


### PR DESCRIPTION
Currently on Linux is not possible to run command async without plugins. `xdg-open` allows to open files or URL's. `&` is not works in Vim. So, I just removed this check. This will avoid error and allow ro run sync at least.
I also reworked launch a bit. What do you think about it?
Also I added support for [Asyncrun](https://github.com/skywind3000/asyncrun.vim). This plugin is very neat, it allow run command async and output everything in a quickfix like IDE in live:
![изображение](https://user-images.githubusercontent.com/22453358/83924478-739b3400-a78d-11ea-99a1-1cf0e9b1b4b5.png)

~P.S. I thinking about autosave feature. It would be nice to save all files automatically before running. What do you think? Should I put an option for autosave in this file too or in `plugin` folder?~