### PR TITLE
Add .gdshader to gsl filetypes

### DIFF
--- a/ftdetect/gsl.vim
+++ b/ftdetect/gsl.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.shader set ft=gsl
+autocmd BufNewFile,BufRead *.gdshader,*.shader set ft=gsl


### PR DESCRIPTION
From 3.3.3 `.gdshader` is the default shader filetype extension
(`.shader` will be no longer supported in 4.0 IIRC)