### PR TITLE
a better exec flags in the neovim docs

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -316,6 +316,6 @@ Open menu `Editor/Editor Settings/` then navigate to `General/External/`:
 
 * Tick `Use external editor`
 * Add `nvr` to `Exec Path`
-* Add `--servername godothost --remote {file}` to `Exec Flags`
+* Add `--servername godothost --remote-send "<C-\><C-N>:n {file}<CR>:call cursor({line},{col})<CR>"` to `Exec Flags`
 
 now when you click on a script in godot it will open it in a new buffer in Neovim.


### PR DESCRIPTION
this command works better 
 "<C-\><C-N>:n {file}<CR>:call cursor({line},{col})<CR>"
It worked for my neovim setup it should work for regular vim though (I don't use it and I don't want to compile it from source with the remote flag so please some test this so I could amend the vim part too)
the current one (in the vim part of the docs) when used in neovim at least takes you to the end of the file if you open a script through godot which is annoying to me