### PR TITLE
fix: GodotRunCurrent won't work

### DIFF
--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -12,10 +12,8 @@ endfunc
 
 " Run current scene
 func! godot#run_current() abort
-    let cwd = getcwd()
-    let scene_name = s:find_scene_name()
-
-    call s:run_scene(cwd . '/' . scene_name)
+    let current_file = expand("%:p")
+    call s:run_scene(current_file)
 endfunc
 
 

--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -12,8 +12,10 @@ endfunc
 
 " Run current scene
 func! godot#run_current() abort
+    let cwd = getcwd()
     let scene_name = s:find_scene_name()
-    call s:run_scene(scene_name)
+
+    call s:run_scene(cwd . '/' . scene_name)
 endfunc
 
 


### PR DESCRIPTION
It seems like the function `godot#run_current()` passed the filename to `run_scene()` instead of the full path. This could resolves into the `run_scene()` function to not be able to run the scene correctly.