### PR TITLE
Set 'comments'

### DIFF
--- a/ftplugin/gdscript.vim
+++ b/ftplugin/gdscript.vim
@@ -9,6 +9,7 @@ set cpo&vim
 
 let b:undo_ftplugin = 'setlocal cinkeys<'
       \ . '|setlocal indentkeys<'
+      \ . '|setlocal comments<'
       \ . '|setlocal commentstring<'
       \ . '|setlocal suffixesadd<'
       \ . '|setlocal foldexpr<'
@@ -19,6 +20,7 @@ setlocal cinkeys-=0#
 setlocal indentkeys-=0#
 setlocal suffixesadd=.gd
 setlocal commentstring=#\ %s
+setlocal comments=b:#,fb:-
 setlocal foldignore=
 setlocal foldexpr=GDScriptFoldLevel()
 setlocal noexpandtab


### PR DESCRIPTION
Set 'comments' in addition to 'commentstring' so plugins (like tpope/commentary) can correctly insert/remove comments.

Copied the value for 'comments' from $VIMRUNTIME/ftplugin/python.vim.