### PR TITLE
Make gf on res:// paths open the correct file

### DIFF
--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -157,7 +157,6 @@ func! godot#convert_res_to_file_path(res_path) abort
     " separators, they'll be treated as escapes.
     let trimmed = substitute(fpath, "^res:/", "", "")
 
-    let g:test_david = ["godot#convert_res_to_file_path", fpath, trimmed, s:project_path()]
     if len(trimmed) < len(fpath)
         let fpath = s:project_path() .. trimmed
         if filereadable(fpath)

--- a/autoload/godot.vim
+++ b/autoload/godot.vim
@@ -88,7 +88,14 @@ endfunc
 
 " Return project path
 func! s:project_path() abort
-    return fnamemodify(findfile("project.godot", ".;"), ":h")
+    " Search from multiple locations so we work even from res:// paths
+    let dirs = ['.', expand("#:p:h")]
+    for d in dirs
+        let root = findfile("project.godot", d ..";")
+        if filereadable(root)
+            return fnamemodify(root, ":h")
+        endif
+    endfor
 endfunc
 
 
@@ -142,3 +149,32 @@ func! godot#fzf_run_scene(...)
                 \}, 0))
 
 endfunc
+
+func! godot#convert_res_to_file_path(res_path) abort
+    let fpath = a:res_path
+
+    " Can't use root in substitute because if it contains backslash directory
+    " separators, they'll be treated as escapes.
+    let trimmed = substitute(fpath, "^res:/", "", "")
+
+    let g:test_david = ["godot#convert_res_to_file_path", fpath, trimmed, s:project_path()]
+    if len(trimmed) < len(fpath)
+        let fpath = s:project_path() .. trimmed
+        if filereadable(fpath)
+            return fpath
+        endif
+    endif
+    
+    return a:res_path
+endfunc
+
+
+func! godot#edit_res_path(res_path) abort
+    let fpath = godot#convert_res_to_file_path(a:res_path)
+    if filereadable(fpath)
+        exec "keepalt edit" fpath
+    else
+        exec "noautocmd edit" a:res_path
+    endif
+endfunc
+

--- a/ftplugin/gdscript.vim
+++ b/ftplugin/gdscript.vim
@@ -8,6 +8,7 @@ let s:keepcpo = &cpo
 set cpo&vim
 
 let b:undo_ftplugin = 'setlocal cinkeys<'
+      \ . '|setlocal includeexpr<'
       \ . '|setlocal indentkeys<'
       \ . '|setlocal commentstring<'
       \ . '|setlocal suffixesadd<'
@@ -58,6 +59,8 @@ nnoremap <silent><buffer>   ]] :<c-u>call <sid>section_start(0, v:count1)<CR>
 nnoremap <silent><buffer>   [[ :<c-u>call <sid>section_start(1, v:count1)<CR>
 xmap <silent><buffer><expr> ]] "\<esc>".v:count1.']]m>gv'
 xmap <silent><buffer><expr> [[ "\<esc>".v:count1.'[[m>gv'
+
+setlocal includeexpr=godot#convert_res_to_file_path(v:fname)
 
 
 let &cpo = s:keepcpo

--- a/plugin/godot.vim
+++ b/plugin/godot.vim
@@ -1,0 +1,4 @@
+augroup godot
+    au! *
+    autocmd BufReadCmd res://* ++nested call godot#edit_res_path(expand("<amatch>"))
+augroup END


### PR DESCRIPTION
~Draft because I haven't tested this enough, but~ I saw your comment on my [related vim question](https://vi.stackexchange.com/questions/38455/how-to-make-gf-replace-res-prefix-with-project-root), so I thought I'd post so you can see and it might be awhile before I work on it again.

----

Fix gf on `extends "res://cars/car_base.gd"` opens `"res://cars/car_base.gd"` instead of `C:/project/cars/car_base.gd`.

The includeexpr isn't sufficient to open these files because vim sees res:// as a valid filepath and fails to invoke it includeexpr. Possibly includeexpr is unnecessary; I don't entirely understand what it's for.

Use a similar method to netrw and use BufReadCmd to capture attempts to edit res:// files and resolve to the intended file. During this resolve, we're already editing the res:// path, so the old
findfile("project.godot", ".;") returns a nonsense path (vim/vim#11060) and we need to try harder.

Test
* gf on a extends line
* edit res://file without ever opening a godot project and it still opens res://file.