### PR TITLE
Add support for Godot4 include shaders

### DIFF
--- a/ftdetect/gsl.vim
+++ b/ftdetect/gsl.vim
@@ -1,1 +1,1 @@
-autocmd BufNewFile,BufRead *.gdshader,*.shader set ft=gsl
+autocmd BufNewFile,BufRead *.gdshader,*gdshaderinc,*.shader set ft=gsl

--- a/ftplugin/gsl.vim
+++ b/ftplugin/gsl.vim
@@ -10,7 +10,7 @@ set cpo&vim
 let b:undo_ftplugin = 'setlocal suffixesadd<'
       \ . '|setlocal noexpandtab<'
 
-setlocal suffixesadd=.shader,.gdshader
+setlocal suffixesadd=.shader,.gdshader,.gdshaderinc
 setlocal noexpandtab
 
 command! -buffer -nargs=? -complete=customlist,godot#scene_complete GodotRun call godot#run(<q-args>)


### PR DESCRIPTION
Godot 4 introduced the [#include](https://docs.godotengine.org/en/latest/tutorials/shaders/shader_reference/shader_preprocessor.html#include) preprocessor which only works with `.gdshaderinc` file types.
I'm suggesting to add the new file extension to the existing list.