### PR TITLE
docs: Align tab behaviour with indent display in ftplugin example

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -68,6 +68,7 @@ Good practice is to put your personal filetype specific settings into after dire
 ------------------------------------------------------------------------------
 " to use folding provided by plugin
 setlocal foldmethod=expr
+setlocal shiftwidth=4
 setlocal tabstop=4
 nnoremap <buffer> <F4> :GodotRunLast<CR>
 nnoremap <buffer> <F5> :GodotRun<CR>


### PR DESCRIPTION
Add `setlocal shiftwidth=4` to README ftplugin example to correct tabbing  behaviour which previously resulted in 8 space indents instead of 4.