### PR TITLE
Support unique nodes starting with %

### DIFF
--- a/syntax/gdscript.vim
+++ b/syntax/gdscript.vim
@@ -54,7 +54,7 @@ if get(g:, "godot_ext_hl", v:true)
     syn match gdscriptFunctionCall "\v<\w*>\s*(\()@="
 endif
 
-syn match gdscriptNode "\$\h\w*\%(/\h\w*\)*"
+syn match gdscriptNode "[\$\%]\h\w*\%(/\h\w*\)*"
 
 syn match gdscriptComment "#.*$" contains=@Spell,gdscriptTodo
 


### PR DESCRIPTION
Unique nodes can be written with a shorthand using percent. For example:

```gdscript
@onready var my_node = $MyNode          # previously supported
@onready var unique_node = %UniqueNode  # newly supported
```

There is another way to write unique nodes, shown below, but I didn't add that to keep this pull request simple.

```gdscript
@onready var my_node = $%MyNode
```