### PR TITLE
Allow jumping to godot quickfix errors

### DIFF
--- a/compiler/godot.vim
+++ b/compiler/godot.vim
@@ -1,0 +1,39 @@
+" Compiler:	godot
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "godot"
+
+if exists(":CompilerSet") != 2		" older Vim always used :setlocal
+  command -nargs=* CompilerSet setlocal <args>
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+CompilerSet errorformat=
+
+" Ignore cpp lines.
+CompilerSet errorformat+=%-G%\\s%#at:%.%#\ \(%.%#.cpp:%\\d%\\+)
+
+" Match filenames including res:// which works because of godot#edit_res_path.
+
+" Use each file and line of backtraces (to see and step through the code executing).
+"  GDScript backtrace (most recent call first):
+"      [0] save_children_states (res://room/room_data.gd:128)
+"      [1] store_states (res://interfaces/i_room.gd:341)
+CompilerSet errorformat+=%*[\ \t][%*[0-9]]\ %m\ (%f:%l)
+
+CompilerSet errorformat+=%tRROR:\ Failed\ to\ load\ script\ \"%f\"\ with\ error\ \"%m\".
+CompilerSet errorformat+=%tRROR:\ %.%#\\,\ script\ \'%f\'%m
+
+" These parse errors have the file on another line.
+CompilerSet errorformat+=%ESCRIPT\ ERROR:\ %m
+CompilerSet errorformat+=%-C%\\s%#at:\ %s\ (%f:%l)
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim:set sw=2 sts=2:
+

--- a/compiler/godot.vim
+++ b/compiler/godot.vim
@@ -32,6 +32,13 @@ CompilerSet errorformat+=%tRROR:\ %.%#\\,\ script\ \'%f\'%m
 CompilerSet errorformat+=%ESCRIPT\ ERROR:\ %m
 CompilerSet errorformat+=%-C%\\s%#at:\ %s\ (%f:%l)
 
+" Match errors from Output window.
+"  ERROR: res://main.gd:8 - Parse Error: Unexpected "Identifier" in class body. (may have preceeding space)
+CompilerSet errorformat+=%*[\ \t]%tRROR:\ %f:%l\ -\ %m
+" res://main.gd:8 - Parse Error: Unexpected "Identifier" in class body.
+CompilerSet errorformat+=%f:%l\ -\ %m
+
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 


### PR DESCRIPTION
When you use :GodotRun, you get output in your quickfix. Some of it has useful error messages. With this compiler, you can jump directly to those errors.

Godot outputs filenames including res:// and we match those directly which works because of godot#edit_res_path from #60.

Additionally, you can paste output from the Output panel and get vim to parse it into something useful. That's great when getting logs from other people.